### PR TITLE
terminal: decode output of sub-processes from bytes to unicode

### DIFF
--- a/core/terminal.py
+++ b/core/terminal.py
@@ -121,7 +121,7 @@ class KDETerminal(LinuxTerminal):
     def get_command_line():
         s = subprocess.check_output(
             ['kreadconfig', '--file', 'kdeglobals', '--group', 'General',
-             '--key', 'TerminalApplication', '--default', 'konsole']).decode().replace(
+             '--key', 'TerminalApplication', '--default', 'konsole']).decode('utf-8').replace(
                  '\n', '')
         return ['nohup', s, '-e']
 
@@ -159,11 +159,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec'
-            ]).decode().replace('\n', '').replace("'", '')
+            ]).decode('utf-8').replace('\n', '').replace("'", '')
             term_arg = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec-arg'
-            ]).decode().replace('\n', '').replace("'", '')
+            ]).decode('utf-8').replace('\n', '').replace("'", '')
             return ['nohup', term, term_arg]
         except: #fallback to older gconf
             pass
@@ -171,11 +171,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec'
-            ]).decode().replace('\n', '')
+            ]).decode('utf-8').replace('\n', '')
             term_arg = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec_arg'
-            ]).decode().replace('\n', '')
+            ]).decode('utf-8').replace('\n', '')
             return ['nohup', term, term_arg]
         except:
             raise Exception("Unable to determine terminal command.")
@@ -188,7 +188,7 @@ class XfceTerminal(LinuxTerminal):
     def detect():
         try:
             s = subprocess.check_output(
-                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT).decode()
+                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT).decode('utf-8')
             return 'xfce' in s
         except:
             return False
@@ -364,7 +364,7 @@ def _terminal_test_report(fn, value):
     while True:
         try:
             with open(fn, 'w+b') as f:
-                f.write(str(value).encode())
+                f.write(str(value).encode('utf-8'))
             return
         except IOError:
             pass

--- a/core/terminal.py
+++ b/core/terminal.py
@@ -121,7 +121,7 @@ class KDETerminal(LinuxTerminal):
     def get_command_line():
         s = subprocess.check_output(
             ['kreadconfig', '--file', 'kdeglobals', '--group', 'General',
-             '--key', 'TerminalApplication', '--default', 'konsole']).replace(
+             '--key', 'TerminalApplication', '--default', 'konsole']).decode().replace(
                  '\n', '')
         return ['nohup', s, '-e']
 
@@ -159,11 +159,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec'
-            ]).replace('\n', '').replace("'", '')
+            ]).decode().replace('\n', '').replace("'", '')
             term_arg = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec-arg'
-            ]).replace('\n', '').replace("'", '')
+            ]).decode().replace('\n', '').replace("'", '')
             return ['nohup', term, term_arg]
         except: #fallback to older gconf
             pass
@@ -171,11 +171,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec'
-            ]).replace('\n', '')
+            ]).decode().replace('\n', '')
             term_arg = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec_arg'
-            ]).replace('\n', '')
+            ]).decode().replace('\n', '')
             return ['nohup', term, term_arg]
         except:
             raise Exception("Unable to determine terminal command.")
@@ -188,7 +188,7 @@ class XfceTerminal(LinuxTerminal):
     def detect():
         try:
             s = subprocess.check_output(
-                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT)
+                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT).decode()
             return 'xfce' in s
         except:
             return False
@@ -364,7 +364,7 @@ def _terminal_test_report(fn, value):
     while True:
         try:
             with open(fn, 'w+b') as f:
-                f.write(str(value))
+                f.write(str(value).encode())
             return
         except IOError:
             pass


### PR DESCRIPTION
fix for #161 (bitbucket issues):  Linux only ??
Makes the terminal handling (custom terminal testing + dfhack terminal) work for both python3 and python2
-> tested on Linux / python 3.7.3/ python 2.7.16 only