### PR TITLE
Fixes for KDETerminal

### DIFF
--- a/core/terminal.py
+++ b/core/terminal.py
@@ -3,7 +3,7 @@
 """Handles terminal detection on Linux and terminal command lines."""
 from __future__ import print_function, unicode_literals, absolute_import
 
-import sys, os, subprocess, tempfile, time
+import sys, os, subprocess, tempfile, time, shutil
 from .lnp import lnp
 from . import log
 
@@ -119,10 +119,11 @@ class KDETerminal(LinuxTerminal):
 
     @staticmethod
     def get_command_line():
-        s = subprocess.check_output(
-            ['kreadconfig', '--file', 'kdeglobals', '--group', 'General',
-             '--key', 'TerminalApplication', '--default', 'konsole']).decode('utf-8').replace(
-                 '\n', '')
+        kreadconfig_path = shutil.which('kreadconfig5') or shutil.which('kreadconfig')
+        s = subprocess.check_output([
+            kreadconfig_path, '--file', 'kdeglobals', '--group', 'General',
+            '--key', 'TerminalApplication', '--default', 'konsole'],
+            universal_newlines=True).replace('\n', '')
         return ['nohup', s, '-e']
 
 class GNOMETerminal(LinuxTerminal):
@@ -159,11 +160,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec'
-            ]).decode('utf-8').replace('\n', '').replace("'", '')
+            ], universal_newlines=True).replace('\n', '').replace("'", '')
             term_arg = subprocess.check_output([
                 'gsettings', 'get',
                 'org.gnome.desktop.default-applications.terminal', 'exec-arg'
-            ]).decode('utf-8').replace('\n', '').replace("'", '')
+            ], universal_newlines=True).replace('\n', '').replace("'", '')
             return ['nohup', term, term_arg]
         except: #fallback to older gconf
             pass
@@ -171,11 +172,11 @@ class GNOMETerminal(LinuxTerminal):
             term = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec'
-            ]).decode('utf-8').replace('\n', '')
+            ], universal_newlines=True).replace('\n', '')
             term_arg = subprocess.check_output([
                 'gconftool-2', '--get',
                 '/desktop/gnome/applications/terminal/exec_arg'
-            ]).decode('utf-8').replace('\n', '')
+            ], universal_newlines=True).replace('\n', '')
             return ['nohup', term, term_arg]
         except:
             raise Exception("Unable to determine terminal command.")
@@ -188,7 +189,8 @@ class XfceTerminal(LinuxTerminal):
     def detect():
         try:
             s = subprocess.check_output(
-                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT).decode('utf-8')
+                ['ps', '-eo', 'comm='], stderr=subprocess.STDOUT,
+                universal_newlines=True)
             return 'xfce' in s
         except:
             return False


### PR DESCRIPTION
- Try to find `kreadconfig5` in PATH, otherwise fall back to `kreadconfig`

Only `kreadconfig5` exists on my Arch Linux installation. Arch Linux is known for not patching upstream, so I assume this is how it is shipped by the latest KDE Plasma version. Some distros might decide to symlink `kreadconfig` to `kreadconfig5` -- this code should support both cases.

- Use `universal_newlines=True` in subprocess calls instead of decoding with UTF-8 always

See the paragraph about `universal_newlines` [here](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module):

> If encoding or errors are specified, or text is true, file objects for stdin, stdout and stderr are opened in text mode using the specified encoding and errors or the io.TextIOWrapper default. The universal_newlines argument is equivalent to text and is provided for backwards compatibility. By default, file objects are opened in binary mode.

And the default encoding for `io.TextIOWrapper` is described [here](https://docs.python.org/3/library/io.html#io.TextIOWrapper):

> encoding gives the name of the encoding that the stream will be decoded or encoded with. It defaults to locale.getpreferredencoding(False).

Which can be found [here](https://docs.python.org/3/library/locale.html#locale.getpreferredencoding). So we can assume this makes the best choice using what can be inferred from the running system, instead of just assuming "UTF-8". I decided to use "universal_newlines" instead of the more-modern "text" keyword-argument, because that was only introduced relatively recently (Python 3.7).