### PR TITLE
Allow ZIP64 when ZIP files would get larger than 4GB

### DIFF
--- a/core/legends_processor.py
+++ b/core/legends_processor.py
@@ -85,13 +85,13 @@ def create_archive():
         l.append(pattern + 'legends_plus.xml')
     if all([os.path.isfile(f) for f in l]):
         with zipfile.ZipFile(pattern + 'legends_archive.zip',
-                             'w', zipfile.ZIP_DEFLATED) as zipped:
+                             'w', zipfile.ZIP_DEFLATED, allowZip64=True) as zipped:
             for f in l:
                 zipped.write(f, os.path.basename(f))
                 os.remove(f)
     elif os.path.isfile(pattern + 'legends.xml'):
         with zipfile.ZipFile(pattern + 'legends_xml.zip',
-                             'w', zipfile.ZIP_DEFLATED) as zipped:
+                             'w', zipfile.ZIP_DEFLATED, allowZip64=True) as zipped:
             zipped.write(pattern + 'legends.xml',
                          os.path.basename(pattern + 'legends.xml'))
             os.remove(pattern + 'legends.xml')


### PR DESCRIPTION
Fixes #166

See [here](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile):

> If allowZip64 is True (the default) zipfile will create ZIP files that use the ZIP64 extensions when the zipfile is larger than 4 GiB. If it is false zipfile will raise an exception when the ZIP file would require ZIP64 extensions.