### PR TITLE
Add import strategy to handle encoding 'ISO-8859-1'

### DIFF
--- a/PyLNP.json
+++ b/PyLNP.json
@@ -15,7 +15,7 @@
 		["DF Forums","http://www.bay12forums.com/smf/"]
 	],
 	"to_import": [
-		["text_prepend", "<df>/gamelog.txt"],
+		["text_prepend_iso_8859_1", "<df>/gamelog.txt"],
 		["text_prepend", "<df>/ss_fix.log"],
 		["text_prepend", "<df>/dfhack.history"],
 		["copy_add", "<df>/data/save"],

--- a/core/importer.py
+++ b/core/importer.py
@@ -10,6 +10,8 @@ Two import strategies are currently supported:
     copy a file or directory contents, non-recursive, no overwriting
 :text_prepend:
     prepend imported file content (for logfiles)
+:text_prepend_iso_8859_1: (variant)
+    prepend imported file content with ISO-8859-1 encoding
 
 
 These strategies support the 'low hanging fruit' of imports.  Other content
@@ -84,7 +86,7 @@ def strat_copy_add(src, dest):
     return ret
 
 
-def strat_text_prepend(src, dest):
+def strat_text_prepend(src, dest, encoding='utf8'):
     """Prepend the src textfile to the dest textfile, creating it if needed."""
     if not os.path.isfile(src):
         log.i('Cannot import {} - not a file'.format(src))
@@ -93,9 +95,9 @@ def strat_text_prepend(src, dest):
         log.i('importing {} to {} by copying'.format(src, dest))
         shutil.copy2(src, dest)
         return True
-    with open(src) as f:
+    with open(src, encoding=encoding) as f:
         srctext = f.read()
-    with open(dest) as f:
+    with open(dest, encoding=encoding) as f:
         desttext = f.read()
     with open(src, 'w') as f:
         log.i('importing {} to {} by prepending'.format(src, dest))
@@ -150,6 +152,7 @@ def do_imports(from_df_dir):
     strat_funcs = {
         'copy_add': strat_copy_add,
         'text_prepend': strat_text_prepend,
+        'text_prepend_iso_8859_1': lambda src, dst: strat_text_prepend(src, dst, encoding='ISO-8859-1')
         }
     imported = []
     for strat, src, dest in path_pairs:

--- a/core/lnp.py
+++ b/core/lnp.py
@@ -167,7 +167,7 @@ class PyLNP(object):
                 ["DF Forums", "http://www.bay12forums.com/smf/"]
             ],
             "to_import": [
-                ['text_prepend', '<df>/gamelog.txt'],
+                ['text_prepend_iso_8859_1', '<df>/gamelog.txt'],
                 ['text_prepend', '<df>/ss_fix.log'],
                 ['text_prepend', '<df>/dfhack.history'],
                 ['copy_add', '<df>/data/save'],


### PR DESCRIPTION
On Linux / Python 3.7, encoding iso-8859-1 is required to import file 'gamelog.txt'.
This patch adds an import strategy to explicitly set this encoding.

Seems to work as well with Linux / Python 2.7.
NOT tested under Windows or MacOS.