### PR TITLE
Create mod subdirs when merging

### DIFF
--- a/core/mods.py
+++ b/core/mods.py
@@ -197,6 +197,15 @@ def merge_folder(mod_folder, vanilla_folder, mixed_folder):
     Text files are merged; other files (sprites etc) are copied over."""
     status = 0
     for root, _, files in os.walk(mod_folder):
+
+        # We want to make any directory in our mod folder in the mixed folder
+        # if it doesn't already exist. Fixes #173
+        mixed_dir = os.path.join(mixed_folder,
+                                 os.path.relpath(root, mod_folder))
+
+        if not os.path.isdir(mixed_dir):
+            os.makedirs(mixed_dir)
+
         for k in files:
             f = os.path.relpath(os.path.join(root, k), mod_folder)
             log.push_prefix('file "' + f + '": ')

--- a/tkgui/tkgui.py
+++ b/tkgui/tkgui.py
@@ -580,7 +580,7 @@ class TkGui(object):
             title='About', message="PyLNP "+VERSION +" - Lazy Newb Pack Python "
             "Edition\n\nPort by Pidgeot\nContributions by PeridexisErrant, "
             "rx80, dricus, James Morgensen, jecowa, carterscottm, McArcady, "
-            "fournm, rgov, cryzed\n\n"
+            "fournm, rgov, cryzed, pjf\n\n"
             "Original program: LucasUP, TolyK/aTolyK")
 
     @staticmethod


### PR DESCRIPTION
## Description

When walking the list of files to merge from a mod, also try to create any subdirectories those files may be in.

## Testing

Used PyLNP to install the HighFantasty mod. Without this change, an error is logged that files cannot be copied. With this change, the files copy across fine, and the merged changes can be applied.

Launched a game with the merged changes applied. Created a world. Started a fortress mode game, and observed that HighFantasty civs like dark gnomes and lizardfolk were active in the world.

This doesn't mean that HighFantasy installs flawlessly (it doesn't), but it no longer errors out from failing to copy files.

## Other information

Thank you so much for PyLNP! It rocks!!

Closes #173