### PR TITLE
Remove white background from file lists

### DIFF
--- a/tkgui/graphics.py
+++ b/tkgui/graphics.py
@@ -200,11 +200,12 @@ class GraphicsTab(Tab):
         packs = self.packs = [p[0] for p in graphics.read_graphics()]
         self.graphics.set(tuple(sorted([graphics.get_title(p) for p in packs])))
         current = graphics.current_pack()
+        default_bg = Style().lookup('TListbox', 'fill')
         for i, p in enumerate(packs):
             if p == current:
                 self.graphicpacks.itemconfig(i, bg='pale green')
             else:
-                self.graphicpacks.itemconfig(i, bg=None)
+                self.graphicpacks.itemconfig(i, bg=default_bg)
 
         self.select_graphics()
 
@@ -300,11 +301,12 @@ class GraphicsTab(Tab):
         files = colors.read_colors()
         self.colors.set(files)
         current = colors.get_installed_file()
+        default_bg = Style().lookup('TListbox', 'fill')
         for i, f in enumerate(files):
             if f == current:
                 self.color_files.itemconfig(i, bg='pale green')
             else:
-                self.color_files.itemconfig(i, bg=None)
+                self.color_files.itemconfig(i, bg=default_bg)
 
         self.select_colors()
 
@@ -387,16 +389,17 @@ class GraphicsTab(Tab):
         files = graphics.read_tilesets()
         self.tilesets.set(files)
         current = graphics.current_tilesets()
+        default_bg = Style().lookup('TListbox', 'fill')
         for i, f in enumerate(files):
             if f == current[0]:
                 self.fonts.itemconfig(i, bg='pale green')
             else:
-                self.fonts.itemconfig(i, bg=None)
+                self.fonts.itemconfig(i, bg=default_bg)
             if lnp.settings.version_has_option('GRAPHICS_FONT'):
                 if f == current[1]:
                     self.graphicsfonts.itemconfig(i, bg='pale green')
                 else:
-                    self.graphicsfonts.itemconfig(i, bg=None)
+                    self.graphicsfonts.itemconfig(i, bg=default_bg)
 
     def install_tilesets(self, mode=3):
         """

--- a/tkgui/graphics.py
+++ b/tkgui/graphics.py
@@ -204,7 +204,7 @@ class GraphicsTab(Tab):
             if p == current:
                 self.graphicpacks.itemconfig(i, bg='pale green')
             else:
-                self.graphicpacks.itemconfig(i, bg='white')
+                self.graphicpacks.itemconfig(i, bg=None)
 
         self.select_graphics()
 
@@ -304,7 +304,7 @@ class GraphicsTab(Tab):
             if f == current:
                 self.color_files.itemconfig(i, bg='pale green')
             else:
-                self.color_files.itemconfig(i, bg='white')
+                self.color_files.itemconfig(i, bg=None)
 
         self.select_colors()
 
@@ -391,12 +391,12 @@ class GraphicsTab(Tab):
             if f == current[0]:
                 self.fonts.itemconfig(i, bg='pale green')
             else:
-                self.fonts.itemconfig(i, bg='white')
+                self.fonts.itemconfig(i, bg=None)
             if lnp.settings.version_has_option('GRAPHICS_FONT'):
                 if f == current[1]:
                     self.graphicsfonts.itemconfig(i, bg='pale green')
                 else:
-                    self.graphicsfonts.itemconfig(i, bg='white')
+                    self.graphicsfonts.itemconfig(i, bg=None)
 
     def install_tilesets(self, mode=3):
         """

--- a/tkgui/options.py
+++ b/tkgui/options.py
@@ -269,7 +269,7 @@ class OptionsTab(Tab):
             if f == current:
                 self.keybinding_files.itemconfig(i, bg='pale green')
             else:
-                self.keybinding_files.itemconfig(i, bg='white')
+                self.keybinding_files.itemconfig(i, bg=None)
 
     def load_keybinds(self):
         """Replaces keybindings with selected file."""
@@ -316,7 +316,7 @@ class OptionsTab(Tab):
             if f in current:
                 self.embark_files.itemconfig(i, bg='pale green')
             else:
-                self.embark_files.itemconfig(i, bg='white')
+                self.embark_files.itemconfig(i, bg=None)
 
     def install_embarks(self, listbox):
         """

--- a/tkgui/options.py
+++ b/tkgui/options.py
@@ -265,11 +265,12 @@ class OptionsTab(Tab):
         files = keybinds.read_keybinds()
         self.keybinds.set(files)
         current = keybinds.get_installed_file()
+        default_bg = Style().lookup('TListbox', 'fill')
         for i, f in enumerate(files):
             if f == current:
                 self.keybinding_files.itemconfig(i, bg='pale green')
             else:
-                self.keybinding_files.itemconfig(i, bg=None)
+                self.keybinding_files.itemconfig(i, bg=default_bg)
 
     def load_keybinds(self):
         """Replaces keybindings with selected file."""
@@ -312,11 +313,12 @@ class OptionsTab(Tab):
         files = embarks.read_embarks()
         self.embarks.set(files)
         current = embarks.get_installed_files()
+        default_bg = Style().lookup('TListbox', 'fill')
         for i, f in enumerate(files):
             if f in current:
                 self.embark_files.itemconfig(i, bg='pale green')
             else:
-                self.embark_files.itemconfig(i, bg=None)
+                self.embark_files.itemconfig(i, bg=default_bg)
 
     def install_embarks(self, listbox):
         """


### PR DESCRIPTION
If your OS is set to use a dark profile, explicitly setting a white
background can make text unreadable. Instead, just leave it at the
default for non-selected files.
