### PR TITLE
fix: Add default parameter value

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -681,7 +681,7 @@ class DFConfiguration(object):
                     filename, self.in_files[files],
                     any((f.endswith('init.txt') for f in files)), files)
 
-    def read_file(self, filename, fields, auto_add, auto_add_key):
+    def read_file(self, filename, fields, auto_add, auto_add_key=None):
         """
         Reads DF settings from the file <filename>.
 


### PR DESCRIPTION
https://github.com/Pidgeot/python-lnp/blob/master/core/graphics.py#L273-L274

These lines have a missing parameter since read_file() was changed recently.
This PR adds a default value to the new parameter in read_file(), so it can be called without having to specify `auto_add_key=False`